### PR TITLE
Linux: "libs-linux" section of dub.json is used to specify libraries

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -24,6 +24,7 @@
 		"targetType": "executable",
 		"targetPath": "bin",
 		"platforms": ["linux", "windows"],
+		"libs-linux": ["SDL2", "SDL2_image", "SDL2_mixer", "SDL2_ttf", "cimgui", "vulkan", "cimgui"],
 		"dflags-windows-x86_64": ["-P-IC:/VulkanSDK/1.4.309.0/Include", 
                               "-P-IC:/VulkanSDK/1.4.309.0/Include/SDL2", 
                               "-P-I./deps/libs/include/", "-P-I./deps/cimgui/", "-P-I./deps/cimgui/imgui/"],
@@ -33,7 +34,7 @@
                               "SDL2main.lib", "SDL2.lib", "SDL2_image.lib", "SDL2_mixer.lib", "SDL2_ttf.lib",
                               "cimgui.lib", "vulkan-1.lib"],
 		"dflags-linux": ["-P-I/usr/include/SDL2/", "-P-I./deps/cimgui/", "-P-I./deps/cimgui/imgui/"],
-		"lflags-linux": ["-L./", "-lSDL2", "-lSDL2_image", "-lSDL2_mixer", "-lSDL2_ttf", "-lcimgui", "-lvulkan"],
+		"lflags-linux": ["-L$PACKAGE_DIR"],
 		"copyFiles-windows-x86_64": [
 			"deps/libs/lib/SDL2_image.dll",
 			"deps/libs/lib/SDL2_mixer.dll",


### PR DESCRIPTION
Hi! I am also interested in Vulkan on D

In this PR I just changed `dub.json` more idiomatically

The build on Debian didn't work for me: dynamic loader never checks the current directory for shared libs unless `$LD_LIBRARY_PATH` isn't set to current directory. So, for Linux build instruction is:
```
$ LD_LIBRARY_PATH=. dub --compiler=ldc2
```

With DMD v2.111.0 build process fails, so I used ldc2 and it starts but fails:
```
INFO: createScene: Finished
core.exception.ArrayIndexError@src/engine/compute.d(299): index [2] is out of bounds for array of length 2
----------------
??:? [0x5567b409e6de]
??:? [0x5567b409e342]
??:? [0x5567b40c57ce]
??:? [0x5567b40a630c]
??:? [0x5567b409d02d]
??:? [0x5567b409d40d]
src/engine/compute.d:299 [0x5567b402468a]
src/engine/window.d:54 [0x5567b40216e2]
src/main.d:50 [0x5567b401f81f]
```

`dub --compiler=dmd` returns:
```
Build complete for Linux
/usr/include/x86_64-linux-gnu/bits/floatn.h(97,26): Error: illegal combination of type specifiers
/usr/include/x86_64-linux-gnu/bits/floatn.h(97,32): Error: illegal type combination
/usr/include/x86_64-linux-gnu/bits/floatn-common.h(214,15): Error: illegal combination of type specifiers
/usr/include/x86_64-linux-gnu/bits/floatn-common.h(251,16): Error: illegal combination of type specifiers
/usr/include/x86_64-linux-gnu/bits/floatn-common.h(268,16): Error: illegal combination of type specifiers
/usr/include/x86_64-linux-gnu/bits/floatn-common.h(285,26): Error: illegal combination of type specifiers
/usr/include/x86_64-linux-gnu/bits/floatn-common.h(285,32): Error: illegal type combination
Error dmd failed with exit code 1.

```
