### PR TITLE
fix: resolve Vulkan descriptor validation errors

### DIFF
--- a/app/src/main/assets/data/shaders/structures.glsl
+++ b/app/src/main/assets/data/shaders/structures.glsl
@@ -40,15 +40,15 @@ struct Mesh {
 };
 
 /// Shader Storage Buffer Objects
-layout (std140, set = 0, binding = BINDING_MESH_SSBO) readonly buffer MeshMatrices {
+layout (std430, set = 0, binding = BINDING_MESH_SSBO) readonly buffer MeshMatrices {
     Mesh meshes[];
 } meshSSBO;
 
-layout (std140, set = 0, binding = BINDING_LIGHT_SSBO) readonly buffer LightMatrices {
+layout (std430, set = 0, binding = BINDING_LIGHT_SSBO) readonly buffer LightMatrices {
     Light lights[];
 } lightSSBO;
 
-layout (std140, set = 0, binding = BINDING_BONES_SSBO) readonly buffer BoneMatrices {
+layout (std430, set = 0, binding = BINDING_BONES_SSBO) readonly buffer BoneMatrices {
     Bone transforms[];
 } boneSSBO;
 

--- a/src/engine.d
+++ b/src/engine.d
@@ -126,8 +126,8 @@ struct App {
   bool showBounds = true;                                                       /// Show bounding boxes
   bool showShadows = false;                                                     /// TODO: Allow shadows to be disabled
   bool showRays = false;                                                        /// Show rays
-  bool hasCompute = false;
-  uint verbose = 2;                                                             /// Be very verbose
+  bool hasCompute = true;
+  uint verbose = 0;                                                             /// Be very verbose
   bool disco = false;                                                           /// TODO: ReAdd Disco mode
   bool rebuild = false;                                                         /// Rebuild the swapChain?
   bool isMinimized = false;                                                     /// isMinimized?

--- a/src/engine.d
+++ b/src/engine.d
@@ -127,7 +127,7 @@ struct App {
   bool showShadows = false;                                                     /// TODO: Allow shadows to be disabled
   bool showRays = false;                                                        /// Show rays
   bool hasCompute = false;
-  uint verbose = 0;                                                             /// Be very verbose
+  uint verbose = 2;                                                             /// Be very verbose
   bool disco = false;                                                           /// TODO: ReAdd Disco mode
   bool rebuild = false;                                                         /// Rebuild the swapChain?
   bool isMinimized = false;                                                     /// isMinimized?

--- a/src/engine/assimp/mesh.d
+++ b/src/engine/assimp/mesh.d
@@ -13,7 +13,7 @@ import vector : euclidean,x,y,z;
 import vertex : Vertex, INSTANCE;
 
 struct Mesh {
-  align(16) int[2] vertices;  /// Start .. End positions in Geometry.vertices array
+  int[2] vertices;  /// Start .. End positions in Geometry.vertices array
   int mid = -1;               /// Mesh Material ID
   int tid = -1;               /// Mesh DIFFUSE ID
   int nid = -1;               /// Mesh NORMALS ID
@@ -33,6 +33,9 @@ void updateMeshInfo(ref App app) {
       }
     }
     app.meshInfo ~= app.objects[o].meshes.array;
+    foreach(ref m; app.objects[o].meshes.array) {
+      if(m.tid > 0 || m.nid > 0 || m.oid > 0) SDL_Log("updateMeshInfo: object[%d] tid=%d nid=%d oid=%d mid=%d", cast(int)o, m.tid, m.nid, m.oid, m.mid);
+    }
   }
   if(needsUpdate) app.buffers["MeshMatrices"].dirty[] = true; // Update all syncIndexes
 }

--- a/src/engine/assimp/mesh.d
+++ b/src/engine/assimp/mesh.d
@@ -20,6 +20,12 @@ struct Mesh {
   int oid = -1;               /// Mesh OPACITY ID
 }
 
+void logMesh(uint i, ref const Mesh m, const(char)* prefix = "meshInfo") {
+  SDL_Log("%s[%d] v=[%d,%d] mid=%d tid=%d nid=%d oid=%d", prefix, i, m.vertices[0], m.vertices[1], m.mid, m.tid, m.nid, m.oid);
+}
+
+void printMeshInfo(const App app) { if(!app.verbose){ return; } foreach(i, ref m; app.meshInfo) logMesh(cast(uint)i, m); }
+
 void updateMeshInfo(ref App app) {
   app.meshInfo.length = 0;
   bool needsUpdate = true;
@@ -33,9 +39,7 @@ void updateMeshInfo(ref App app) {
       }
     }
     app.meshInfo ~= app.objects[o].meshes.array;
-    foreach(ref m; app.objects[o].meshes.array) {
-      if(m.tid > 0 || m.nid > 0 || m.oid > 0) SDL_Log("updateMeshInfo: object[%d] tid=%d nid=%d oid=%d mid=%d", cast(int)o, m.tid, m.nid, m.oid, m.mid);
-    }
+    app.printMeshInfo();
   }
   if(needsUpdate) app.buffers["MeshMatrices"].dirty[] = true; // Update all syncIndexes
 }

--- a/src/engine/compute.d
+++ b/src/engine/compute.d
@@ -124,20 +124,6 @@ void updateComputeUBO(ref App app, uint syncIndex = 0){
   }
 }
 
-void writeComputeImage(App app, ref VkWriteDescriptorSet[] write, Descriptor descriptor, VkDescriptorSet dst, ref VkDescriptorImageInfo[] imageInfos){
-  imageInfos ~= VkDescriptorImageInfo(null, app.textures[app.textures.idx(descriptor.name)].view, VK_IMAGE_LAYOUT_GENERAL);
-  VkWriteDescriptorSet set = {
-    sType: VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET,
-    dstSet: dst,
-    dstBinding: descriptor.binding,
-    dstArrayElement: 0,
-    descriptorType: VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
-    descriptorCount: descriptor.count,
-    pImageInfo: &imageInfos[($-1)]
-  };
-  write ~= set;
-}
-
 void createStorageImage(ref App app, Descriptor descriptor){
   VkImageUsageFlags usage;
   usage |= VK_IMAGE_USAGE_TRANSFER_SRC_BIT;

--- a/src/engine/descriptor.d
+++ b/src/engine/descriptor.d
@@ -5,20 +5,18 @@
 
 import engine;
 
-import compute : writeComputeImage;
-import images : writeHDRSampler;
 import lights : updateLighting;
-import sampler : writeTextureSampler;
-import shadow : writeShadowMap;
-import ssbo : writeSSBO, updateSSBO;
+import ssbo : updateSSBO;
 import textures : idx;
-import uniforms : writeUniformBuffer;
 import validation : nameVulkanObject;
+
+enum DescriptorTarget { None, Textures, Shadow, HDR, Compute }
 
 struct Descriptor {
   VkDescriptorType type;    /// Type of Descriptor
-  string name;        /// Name
-  string base;        /// Base / Struct Name
+  string name;              /// Name
+  string base;              /// Base / Struct Name
+  DescriptorTarget target;  /// Image target (resolved at load time, avoids per-frame string dispatch)
   size_t bytes;             /// Size  of the structure
   size_t nObjects;          /// Number of objects stored
 
@@ -200,6 +198,71 @@ void createDescriptors(ref App app, Shader[] shaders, Stage stage = Stage.RENDER
   });
 }
 
+/** Helper to assemble a VkWriteDescriptorSet
+ */
+VkWriteDescriptorSet makeWrite(VkDescriptorSet dst, uint binding, VkDescriptorType type,
+                               VkDescriptorImageInfo* img, VkDescriptorBufferInfo* buf) {
+  VkWriteDescriptorSet set = {
+    sType: VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET,
+    dstSet: dst, dstBinding: binding, dstArrayElement: 0,
+    descriptorType: type, descriptorCount: 1,
+    pImageInfo: img, pBufferInfo: buf
+  };
+  return set;
+}
+
+/** Populate imageInfos for a given descriptor target
+ */
+void writeImageInfos(ref App app, ref VkDescriptorImageInfo[] imageInfos, Descriptor d) {
+  final switch(d.target) {
+    case DescriptorTarget.Textures:
+      if(app.trace) SDL_Log("writeImageInfos(Textures): syncIndex=%d writing %d textures to binding=%d", app.syncIndex, cast(uint)app.textures.length, d.binding);
+      foreach(ref t; app.textures.textures)
+        imageInfos ~= VkDescriptorImageInfo(imageLayout: VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, imageView: t.view, sampler: app.sampler);
+      break;
+    case DescriptorTarget.Shadow:
+      if(app.verbose) SDL_Log("writeImageInfos(Shadow)");
+      foreach(i; 0 .. app.lights.length)
+        imageInfos ~= VkDescriptorImageInfo(imageLayout: VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, imageView: app.shadows.images[i].view, sampler: app.sampler);
+      break;
+    case DescriptorTarget.HDR:
+      imageInfos ~= VkDescriptorImageInfo(imageLayout: VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, imageView: app.resolvedHDR.view, sampler: app.sampler);
+      break;
+    case DescriptorTarget.Compute:
+      imageInfos ~= VkDescriptorImageInfo(imageView: app.textures[app.textures.idx(d.name)].view, imageLayout: VK_IMAGE_LAYOUT_GENERAL);
+      break;
+    case DescriptorTarget.None: break;
+  }
+}
+
+/** Write a single descriptor (buffer or image) into the write + info arrays
+ */
+void writeDescriptor(ref App app, ref VkWriteDescriptorSet[] write,
+                     ref VkDescriptorBufferInfo[] bufferInfos,
+                     ref VkDescriptorImageInfo[] imageInfos,
+                     Descriptor d, VkDescriptorSet dst, uint syncIndex) {
+  size_t start = imageInfos.length;
+  // SSBO Buffer Write
+  if(d.type == VK_DESCRIPTOR_TYPE_STORAGE_BUFFER) {
+    if(app.verbose) SDL_Log("writeDescriptor SSBO %s = %d (%d x %d)", toStringz(d.base), d.size, d.bytes, d.nObjects);
+    bufferInfos ~= VkDescriptorBufferInfo(app.buffers[d.base].buffers[syncIndex], 0, d.size);
+    write ~= makeWrite(dst, d.binding, d.type, null, &bufferInfos[$-1]);
+  }
+  // Uniform Buffer Write
+  if(d.type == VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER) {
+    if(app.verbose) SDL_Log("writeDescriptor UBO[%s] #%d", toStringz(d.base), syncIndex);
+    bufferInfos ~= VkDescriptorBufferInfo(app.ubos[d.base].buffers[syncIndex], 0, d.bytes);
+    write ~= makeWrite(dst, d.binding, d.type, null, &bufferInfos[$-1]);
+  }
+  // Image sampler / Compute Stored Image Write
+  if(d.type == VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER || d.type == VK_DESCRIPTOR_TYPE_STORAGE_IMAGE) {
+    app.writeImageInfos(imageInfos, d);
+    VkWriteDescriptorSet set = makeWrite(dst, d.binding, d.type, &imageInfos[start], null);
+    set.descriptorCount = cast(uint)(imageInfos.length - start);
+    write ~= set;
+  }
+}
+
 /** Update the DescriptorSet
  */
 void updateDescriptorSet(ref App app, Shader[] shaders, VkDescriptorSet[] dstSet, uint syncIndex = 0) {
@@ -208,34 +271,10 @@ void updateDescriptorSet(ref App app, Shader[] shaders, VkDescriptorSet[] dstSet
   VkDescriptorBufferInfo[] bufferInfos;     // Buffer information for this update
   VkDescriptorImageInfo[] imageInfos;       // Image information for this update
 
-  for(uint s = 0; s < shaders.length; s++) {
-    auto shader = shaders[s];
-    for(uint d = 0; d < shader.descriptors.length; d++) {
-      if(app.trace) SDL_Log(toStringz(format("- Descriptor[%d]: '%s'", shader.descriptors[d].binding, shader.descriptors[d])));
-      // Image sampler write
-      if(shader.descriptors[d].type == VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER) {
-        if(shader.descriptors[d].name == "textureSampler") {
-          app.writeTextureSampler(descriptorWrites, shader.descriptors[d], dstSet[syncIndex], imageInfos);
-        }
-        if(shader.descriptors[d].name == "shadowMap"){
-          app.writeShadowMap(descriptorWrites, shader.descriptors[d], dstSet[syncIndex], imageInfos);
-        }
-        if(shader.descriptors[d].name == "hdrSampler"){
-          app.writeHDRSampler(descriptorWrites, shader.descriptors[d], dstSet[syncIndex], imageInfos);
-        }
-      }
-      // Uniform Buffer Write
-      if(shader.descriptors[d].type == VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER) {
-        app.writeUniformBuffer(descriptorWrites, shader.descriptors[d], dstSet, bufferInfos, syncIndex);
-      }
-      // SSBO Buffer Write
-      if(shader.descriptors[d].type == VK_DESCRIPTOR_TYPE_STORAGE_BUFFER) {
-        app.writeSSBO(descriptorWrites, shader.descriptors[d], dstSet, bufferInfos, syncIndex);
-      }
-      // Compute Stored Image
-      if(shader.descriptors[d].type == VK_DESCRIPTOR_TYPE_STORAGE_IMAGE) {
-        app.writeComputeImage(descriptorWrites, shader.descriptors[d], dstSet[syncIndex], imageInfos);
-      }
+  foreach(shader; shaders) {
+    foreach(d; shader.descriptors) {
+      if(app.trace) SDL_Log(toStringz(format("- Descriptor[%d]: '%s'", d.binding, d)));
+      app.writeDescriptor(descriptorWrites, bufferInfos, imageInfos, d, dstSet[syncIndex], syncIndex);
     }
   }
   vkUpdateDescriptorSets(app.device, cast(uint)descriptorWrites.length, &descriptorWrites[0], 0, null);

--- a/src/engine/descriptor.d
+++ b/src/engine/descriptor.d
@@ -14,9 +14,10 @@ enum DescriptorTarget { None, Textures, Shadow, HDR, Compute }
 
 struct Descriptor {
   VkDescriptorType type;    /// Type of Descriptor
+  DescriptorTarget target;  /// Image target (resolved at load time, avoids per-frame string dispatch)
+
   string name;              /// Name
   string base;              /// Base / Struct Name
-  DescriptorTarget target;  /// Image target (resolved at load time, avoids per-frame string dispatch)
   size_t bytes;             /// Size  of the structure
   size_t nObjects;          /// Number of objects stored
 
@@ -70,7 +71,7 @@ struct DescriptorLayoutBuilder {
   }
 };
 
-VkDescriptorSetLayout createDescriptorSetLayout(ref App app, Shader[] shaders){
+VkDescriptorSetLayout createDescriptorSetLayout(ref App app, Shader[] shaders) {
   DescriptorLayoutBuilder builder;
   foreach(shader; shaders) {
     foreach(descriptor; shader.descriptors) {
@@ -82,7 +83,7 @@ VkDescriptorSetLayout createDescriptorSetLayout(ref App app, Shader[] shaders){
   return(layout);
 }
 
-VkDescriptorPoolSize[] createPoolSizes(ref App app, Shader[] shaders){
+VkDescriptorPoolSize[] createPoolSizes(ref App app, Shader[] shaders) {
   VkDescriptorPoolSize[] poolSizes;
   foreach(shader; shaders) {
     foreach(descriptor; shader.descriptors) {
@@ -92,7 +93,7 @@ VkDescriptorPoolSize[] createPoolSizes(ref App app, Shader[] shaders){
   return(poolSizes);
 }
 
-void createDSPool(ref App app, string poolID, VkDescriptorPoolSize[] poolSizes, uint maxSets = 1024){
+void createDSPool(ref App app, string poolID, VkDescriptorPoolSize[] poolSizes, uint maxSets = 1024) {
   if(app.verbose) SDL_Log("Creating DescriptorPool[%s]", toStringz(poolID));
   app.pools[poolID] = VkDescriptorPool();
   VkDescriptorPoolCreateInfo createPool = {
@@ -109,7 +110,7 @@ void createDSPool(ref App app, string poolID, VkDescriptorPoolSize[] poolSizes, 
 
 /** ImGui DescriptorPool (Images)
  */
-void createImGuiDescriptorPool(ref App app){
+void createImGuiDescriptorPool(ref App app) {
   VkDescriptorPoolSize[] poolSizes = [{
     type : VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
     descriptorCount : 1000 ///IMGUI_IMPL_VULKAN_MINIMUM_IMAGE_SAMPLER_POOL_SIZE
@@ -200,8 +201,7 @@ void createDescriptors(ref App app, Shader[] shaders, Stage stage = Stage.RENDER
 
 /** Helper to assemble a VkWriteDescriptorSet
  */
-VkWriteDescriptorSet makeWrite(VkDescriptorSet dst, uint binding, VkDescriptorType type,
-                               VkDescriptorImageInfo* img, VkDescriptorBufferInfo* buf) {
+VkWriteDescriptorSet makeWrite(VkDescriptorSet dst, uint binding, VkDescriptorType type, VkDescriptorImageInfo* img, VkDescriptorBufferInfo* buf) {
   VkWriteDescriptorSet set = {
     sType: VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET,
     dstSet: dst, dstBinding: binding, dstArrayElement: 0,
@@ -216,20 +216,39 @@ VkWriteDescriptorSet makeWrite(VkDescriptorSet dst, uint binding, VkDescriptorTy
 void writeImageInfos(ref App app, ref VkDescriptorImageInfo[] imageInfos, Descriptor d) {
   final switch(d.target) {
     case DescriptorTarget.Textures:
-      if(app.trace) SDL_Log("writeImageInfos(Textures): syncIndex=%d writing %d textures to binding=%d", app.syncIndex, cast(uint)app.textures.length, d.binding);
-      foreach(ref t; app.textures.textures)
-        imageInfos ~= VkDescriptorImageInfo(imageLayout: VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, imageView: t.view, sampler: app.sampler);
+      foreach(ref img; app.textures.textures) {
+        VkDescriptorImageInfo info = {
+          imageLayout: VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+          imageView: img.view,
+          sampler: app.sampler
+        };
+        imageInfos ~= info;
+      }
       break;
     case DescriptorTarget.Shadow:
-      if(app.verbose) SDL_Log("writeImageInfos(Shadow)");
-      foreach(i; 0 .. app.lights.length)
-        imageInfos ~= VkDescriptorImageInfo(imageLayout: VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, imageView: app.shadows.images[i].view, sampler: app.sampler);
+      foreach(ref img; app.shadows.images) {
+        VkDescriptorImageInfo info = {
+          imageLayout: VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+          imageView: img.view,
+          sampler: app.sampler
+        };
+        imageInfos ~= info;
+      }
       break;
     case DescriptorTarget.HDR:
-      imageInfos ~= VkDescriptorImageInfo(imageLayout: VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, imageView: app.resolvedHDR.view, sampler: app.sampler);
+      VkDescriptorImageInfo info = {
+        imageLayout: VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+        imageView: app.resolvedHDR.view,
+        sampler: app.sampler
+      };
+      imageInfos ~= info;
       break;
     case DescriptorTarget.Compute:
-      imageInfos ~= VkDescriptorImageInfo(imageView: app.textures[app.textures.idx(d.name)].view, imageLayout: VK_IMAGE_LAYOUT_GENERAL);
+      VkDescriptorImageInfo info = {
+        imageLayout: VK_IMAGE_LAYOUT_GENERAL,
+        imageView: app.textures[app.textures.idx(d.name)].view,
+      };
+      imageInfos ~= info;
       break;
     case DescriptorTarget.None: break;
   }

--- a/src/engine/descriptor.d
+++ b/src/engine/descriptor.d
@@ -46,13 +46,26 @@ struct DescriptorLayoutBuilder {
   void clear(){ bindings = []; }
 
   VkDescriptorSetLayout build(VkDevice device, VkDescriptorSetLayoutCreateFlags flags = 0, void* pNext = null){
+    VkDescriptorBindingFlags[] bindingFlags;
+    bindingFlags.length = bindings.length;
+    foreach(i, ref b; bindings) { 
+      bindingFlags[i] = (b.descriptorCount > 1) ? VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT : 0;
+    }
+
+    VkDescriptorSetLayoutBindingFlagsCreateInfo bindingFlagsInfo = {
+      sType: VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO,
+      bindingCount: cast(uint)bindingFlags.length,
+      pBindingFlags: &bindingFlags[0]
+    };
+
     VkDescriptorSetLayoutCreateInfo info = {
       sType: VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO,
       pBindings: &bindings[0],
       bindingCount: cast(uint)bindings.length,
       flags: flags,
-      pNext: pNext
+      pNext: &bindingFlagsInfo
     };
+
     VkDescriptorSetLayout set;
     enforceVK(vkCreateDescriptorSetLayout(device, &info, null, &set));
     return set;

--- a/src/engine/devices.d
+++ b/src/engine/devices.d
@@ -52,6 +52,7 @@ void createLogicalDevice(ref App app, uint device = 0, uint queueCount = 2){
     runtimeDescriptorArray : VK_TRUE,
     shaderSampledImageArrayNonUniformIndexing : VK_TRUE,
     shaderStorageBufferArrayNonUniformIndexing : VK_TRUE,
+    descriptorBindingPartiallyBound : VK_TRUE,
     pNext : null
   };
 

--- a/src/engine/images.d
+++ b/src/engine/images.d
@@ -38,27 +38,6 @@ void createColorResources(ref App app) {
   app.createHDRImage(app.resolvedHDR, VK_SAMPLE_COUNT_1_BIT, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_SAMPLED_BIT);
 }
 
-/** writeHDRSampler
- */
-void writeHDRSampler(App app, ref VkWriteDescriptorSet[] write, Descriptor descriptor, VkDescriptorSet dst, ref VkDescriptorImageInfo[] imageInfos){
-  imageInfos ~= VkDescriptorImageInfo(
-    imageLayout: VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
-    imageView: app.resolvedHDR.view,
-    sampler: app.sampler
-  );
-
-  VkWriteDescriptorSet set = {
-    sType: VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET,
-    dstSet: dst,
-    dstBinding: descriptor.binding,
-    dstArrayElement: 0,
-    descriptorType: VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-    descriptorCount: cast(uint)1,
-    pImageInfo: &imageInfos[($-1)]
-  };
-  write ~= set;
-}
-
 /** Create & bind an Image on GPU backed with memory
  */
 void createImage(ref App app, uint width, uint height, VkImage* image, VkDeviceMemory* imageMemory, 

--- a/src/engine/reflection.d
+++ b/src/engine/reflection.d
@@ -115,7 +115,7 @@ Descriptor reflectDescriptor(ref App app, spvc_compiler compiler, const(char)* t
         descr.count *= spvc_type_get_array_dimension(type_handle, x);
       }
     }
-    if(!descr.count){
+    if(!descr.count) {
       descr.count = cast(uint)512;
       if(to!string(descr.name) == "shadowMap"){ descr.count = cast(uint)app.lights.length; }
       if(to!string(descr.name) == "hdrSampler"){ descr.count = 1; }
@@ -184,9 +184,9 @@ VkDescriptorType convert(spvc_resource_type type) {
   }
 }
 
-const(char)* check(string inp){ return(toStringz((inp == "")?"(none)":inp)); }
+const(char)* check(string inp) { return(toStringz((inp == "")? "(none)" : inp)); }
 
-void createReflectionContext(ref App app){
+void createReflectionContext(ref App app) {
   spvc_result result = spvc_context_create(&app.context);
   if(result != SPVC_SUCCESS) {
     SDL_Log("Failed to create SPIRV-Cross context: %s", spvc_context_get_last_error_string(app.context));
@@ -216,3 +216,4 @@ const(char)* convert(spvc_basetype basetype) {
         default: return "unhandled_basetype";
     }
 }
+

--- a/src/engine/reflection.d
+++ b/src/engine/reflection.d
@@ -5,7 +5,7 @@
 
 import engine;
 
-import descriptor : createDSPool;
+import descriptor : createDSPool, DescriptorTarget;
 import compute : createStorageImage, transferToSSBO;
 import ssbo : createSSBO;
 import uniforms : createUBO;
@@ -120,6 +120,13 @@ Descriptor reflectDescriptor(ref App app, spvc_compiler compiler, const(char)* t
       if(to!string(descr.name) == "shadowMap"){ descr.count = cast(uint)app.lights.length; }
       if(to!string(descr.name) == "hdrSampler"){ descr.count = 1; }
     }
+    // Resolve image target once at load time (avoids per-frame string dispatch in updateDescriptorSet)
+    if(descr.type == VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER) {
+      if(to!string(descr.name) == "textureSampler")  descr.target = DescriptorTarget.Textures;
+      else if(to!string(descr.name) == "shadowMap")  descr.target = DescriptorTarget.Shadow;
+      else if(to!string(descr.name) == "hdrSampler") descr.target = DescriptorTarget.HDR;
+    }
+    if(descr.type == VK_DESCRIPTOR_TYPE_STORAGE_IMAGE) descr.target = DescriptorTarget.Compute;
     if (app.trace) {
       SDL_Log(" - %d x %s: %s of %s layout(set=%u, binding = %u), size: %d", 
               descr.count, type, check(descr.name), check(descr.base), descr.set, descr.binding, descr.bytes);

--- a/src/engine/sampler.d
+++ b/src/engine/sampler.d
@@ -42,6 +42,7 @@ void createSampler(ref App app) {
 }
 
 void writeTextureSampler(ref App app, ref VkWriteDescriptorSet[] write, Descriptor descriptor, VkDescriptorSet dst, ref VkDescriptorImageInfo[] imageInfos){
+  SDL_Log("writeTextureSampler: syncIndex=%d writing %d textures to binding=%d", app.syncIndex, cast(uint)app.textures.length, descriptor.binding);
   size_t startIndex = imageInfos.length;
 
   for (size_t i = 0; i < app.textures.length; i++) {

--- a/src/engine/sampler.d
+++ b/src/engine/sampler.d
@@ -41,28 +41,4 @@ void createSampler(ref App app) {
   if(app.verbose) SDL_Log("Created TextureSampler: %p", app.sampler);
 }
 
-void writeTextureSampler(ref App app, ref VkWriteDescriptorSet[] write, Descriptor descriptor, VkDescriptorSet dst, ref VkDescriptorImageInfo[] imageInfos){
-  if(app.trace) {
-    SDL_Log("writeTextureSampler: syncIndex=%d writing %d textures to binding=%d", app.syncIndex, cast(uint)app.textures.length, descriptor.binding);
-  }
-  size_t startIndex = imageInfos.length;
 
-  for (size_t i = 0; i < app.textures.length; i++) {
-    VkDescriptorImageInfo textureImage = {
-      imageLayout: VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
-      imageView: app.textures[i].view,
-      sampler: app.sampler
-    };
-    imageInfos ~= textureImage;
-  }
-  VkWriteDescriptorSet set = {
-    sType: VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET,
-    dstSet: dst,
-    dstBinding: descriptor.binding,
-    dstArrayElement: 0,
-    descriptorType: VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-    descriptorCount: cast(uint)app.textures.length,
-    pImageInfo: &imageInfos[startIndex]
-  };
-  write ~= set;
-}

--- a/src/engine/sampler.d
+++ b/src/engine/sampler.d
@@ -42,7 +42,9 @@ void createSampler(ref App app) {
 }
 
 void writeTextureSampler(ref App app, ref VkWriteDescriptorSet[] write, Descriptor descriptor, VkDescriptorSet dst, ref VkDescriptorImageInfo[] imageInfos){
-  SDL_Log("writeTextureSampler: syncIndex=%d writing %d textures to binding=%d", app.syncIndex, cast(uint)app.textures.length, descriptor.binding);
+  if(app.trace) {
+    SDL_Log("writeTextureSampler: syncIndex=%d writing %d textures to binding=%d", app.syncIndex, cast(uint)app.textures.length, descriptor.binding);
+  }
   size_t startIndex = imageInfos.length;
 
   for (size_t i = 0; i < app.textures.length; i++) {

--- a/src/engine/shadow.d
+++ b/src/engine/shadow.d
@@ -231,29 +231,6 @@ void updateShadowMapUBO(ref App app, Shader[] shaders, uint syncIndex) {
   if(app.trace) SDL_Log("Light space matrix updated for frame %d", app.totalFramesRendered);
 }
 
-void writeShadowMap(App app, ref VkWriteDescriptorSet[] write, Descriptor descriptor, VkDescriptorSet dst, ref VkDescriptorImageInfo[] imageInfos){
-  if(app.verbose) SDL_Log("writeShadowMap");
-  size_t startIndex = imageInfos.length;
-
-  for (size_t i = 0; i < app.lights.length; i++) {
-    imageInfos ~= VkDescriptorImageInfo( // Assign directly to the single info struct
-      imageLayout: VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
-      imageView: app.shadows.images[i].view, // Use the shadow map's image view
-      sampler: app.sampler     // Use the shadow map's sampler
-    );
-  }
-  VkWriteDescriptorSet set = {
-    sType: VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET,
-    dstSet: dst,
-    dstBinding: descriptor.binding,
-    dstArrayElement: 0,
-    descriptorType: VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-    descriptorCount: cast(uint)app.lights.length,
-    pImageInfo: &imageInfos[startIndex]
-  }; 
-  write ~= set;
-}
-
 void recordShadowCommandBuffer(ref App app, uint syncIndex) {
   vkResetCommandBuffer(app.shadowBuffers[syncIndex], 0); // Reset for recording
 

--- a/src/engine/ssbo.d
+++ b/src/engine/ssbo.d
@@ -37,6 +37,7 @@ void createSSBO(ref App app, ref Descriptor descriptor, uint nObjects = 1000) {
                      VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT, 
                      VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
     vkMapMemory(app.device, app.buffers[descriptor.base].memory[i], 0, descriptor.size, 0, &app.buffers[descriptor.base].data[i]);
+    SDL_Log("createSSBO: %s, nObjects=%d, size=%d", toStringz(descriptor.base), nObjects, descriptor.size);
     app.buffers[descriptor.base].dirty[i] = true;
   }
   app.nameSSBO(app.buffers[descriptor.base], descriptor.base);
@@ -66,6 +67,7 @@ void updateSSBO(T)(ref App app, VkCommandBuffer cmdBuffer, T[] objects, Descript
   uint size = cast(uint)(T.sizeof * objects.length);
   if(size == 0) return;
   if(!app.buffers[descriptor.base].dirty[syncIndex]) return;
+  SDL_Log("updateSSBO: %s syncIndex=%d objects=%d", toStringz(descriptor.base), syncIndex, cast(uint)objects.length);
   memcpy(app.buffers[descriptor.base].data[syncIndex], &objects[0], size);
   app.buffers[descriptor.base].dirty[syncIndex] = false; // TODO: enable dirty
 }

--- a/src/engine/ssbo.d
+++ b/src/engine/ssbo.d
@@ -37,7 +37,7 @@ void createSSBO(ref App app, ref Descriptor descriptor, uint nObjects = 1000) {
                      VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT, 
                      VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
     vkMapMemory(app.device, app.buffers[descriptor.base].memory[i], 0, descriptor.size, 0, &app.buffers[descriptor.base].data[i]);
-    SDL_Log("createSSBO: %s, nObjects=%d, size=%d", toStringz(descriptor.base), nObjects, descriptor.size);
+    if(app.trace) SDL_Log("createSSBO: %s, nObjects=%d, size=%d", toStringz(descriptor.base), nObjects, descriptor.size);
     app.buffers[descriptor.base].dirty[i] = true;
   }
   app.nameSSBO(app.buffers[descriptor.base], descriptor.base);
@@ -67,7 +67,7 @@ void updateSSBO(T)(ref App app, VkCommandBuffer cmdBuffer, T[] objects, Descript
   uint size = cast(uint)(T.sizeof * objects.length);
   if(size == 0) return;
   if(!app.buffers[descriptor.base].dirty[syncIndex]) return;
-  SDL_Log("updateSSBO: %s syncIndex=%d objects=%d", toStringz(descriptor.base), syncIndex, cast(uint)objects.length);
+  if(app.trace) SDL_Log("updateSSBO: %s syncIndex=%d objects=%d", toStringz(descriptor.base), syncIndex, cast(uint)objects.length);
   memcpy(app.buffers[descriptor.base].data[syncIndex], &objects[0], size);
   app.buffers[descriptor.base].dirty[syncIndex] = false; // TODO: enable dirty
 }

--- a/src/engine/ssbo.d
+++ b/src/engine/ssbo.d
@@ -48,21 +48,6 @@ void createSSBO(ref App app, ref Descriptor descriptor, uint nObjects = 1000) {
   });
 }
 
-void writeSSBO(App app, ref VkWriteDescriptorSet[] write, Descriptor descriptor, VkDescriptorSet[] dst, ref VkDescriptorBufferInfo[] bufferInfos, uint syncIndex = 0){
-  if(app.verbose) SDL_Log("writeSSBO %s = %d (%d x %d)", toStringz(descriptor.base), descriptor.size, descriptor.bytes, descriptor.nObjects);
-  bufferInfos ~= VkDescriptorBufferInfo(app.buffers[descriptor.base].buffers[syncIndex], 0, descriptor.size);
-  VkWriteDescriptorSet set = {
-    sType: VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET,
-    dstSet: dst[syncIndex],
-    dstBinding: descriptor.binding,
-    dstArrayElement: 0,
-    descriptorType: VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
-    descriptorCount: 1,
-    pBufferInfo: &bufferInfos[($-1)]
-  };
-  write ~= set;
-}
-
 void updateSSBO(T)(ref App app, VkCommandBuffer cmdBuffer, T[] objects, Descriptor descriptor, uint syncIndex) {
   uint size = cast(uint)(T.sizeof * objects.length);
   if(size == 0) return;

--- a/src/engine/textures.d
+++ b/src/engine/textures.d
@@ -106,9 +106,7 @@ void mapTextures(ref App app){
 void mapTextures(ref App app, ref Geometry object){
   foreach (ref mesh; object.meshes) {
     if(mesh.mid < 0) continue;
-    int oldTid = mesh.tid;
     mesh.tid = app.getTexture(object, mesh.mid, aiTextureType_DIFFUSE);
-   if(mesh.tid != oldTid) SDL_Log("mapTextures: tid changed %d -> %d (textures.length=%d)", oldTid, mesh.tid, cast(uint)app.textures.length);
     mesh.nid = app.getTexture(object, mesh.mid, aiTextureType_NORMALS);
     mesh.oid = app.getTexture(object, mesh.mid, aiTextureType_OPACITY);
   }
@@ -119,8 +117,9 @@ void updateTextures(ref App app) {
   for(uint i = 0; i < app.textures.length; i++) { 
     if(app.textures[i].dirty) {
       needsUpdate = true;
-      SDL_Log("updateTextures: syncIndex=%d texture[%d].syncIndex=%d transfer=%d", app.syncIndex, i, app.textures[i].syncIndex, app.textures.transfer);
-
+      if(app.trace) {
+        SDL_Log("updateTextures: syncIndex=%d texture[%d].syncIndex=%d transfer=%d", app.syncIndex, i, app.textures[i].syncIndex, app.textures.transfer);
+      }
       if(app.textures[i].syncIndex == app.syncIndex) { // We are round, we updated all the descriptors for each Frame in Flight
         app.textures[i].dirty = false;
         app.textures[i].syncIndex = -1;
@@ -132,7 +131,7 @@ void updateTextures(ref App app) {
     }
   }
   if(needsUpdate) {
-    SDL_Log("updateTextures: updating descriptor set syncIndex=%d textures.length=%d", app.syncIndex, app.textures.length);
+    if(app.trace) SDL_Log("updateTextures: updating descriptor set syncIndex=%d textures.length=%d", app.syncIndex, app.textures.length);
     app.updateDescriptorSet(app.shaders, app.sets[Stage.RENDER], app.syncIndex);
   }
 }

--- a/src/engine/textures.d
+++ b/src/engine/textures.d
@@ -106,7 +106,9 @@ void mapTextures(ref App app){
 void mapTextures(ref App app, ref Geometry object){
   foreach (ref mesh; object.meshes) {
     if(mesh.mid < 0) continue;
+    int oldTid = mesh.tid;
     mesh.tid = app.getTexture(object, mesh.mid, aiTextureType_DIFFUSE);
+   if(mesh.tid != oldTid) SDL_Log("mapTextures: tid changed %d -> %d (textures.length=%d)", oldTid, mesh.tid, cast(uint)app.textures.length);
     mesh.nid = app.getTexture(object, mesh.mid, aiTextureType_NORMALS);
     mesh.oid = app.getTexture(object, mesh.mid, aiTextureType_OPACITY);
   }
@@ -117,16 +119,20 @@ void updateTextures(ref App app) {
   for(uint i = 0; i < app.textures.length; i++) { 
     if(app.textures[i].dirty) {
       needsUpdate = true;
+      SDL_Log("updateTextures: syncIndex=%d texture[%d].syncIndex=%d transfer=%d", app.syncIndex, i, app.textures[i].syncIndex, app.textures.transfer);
+
       if(app.textures[i].syncIndex == app.syncIndex) { // We are round, we updated all the descriptors for each Frame in Flight
         app.textures[i].dirty = false;
         app.textures[i].syncIndex = -1;
+        app.mapTextures();
         needsUpdate = false;
       } else if(app.textures[i].syncIndex == -1) { // Dirty and not in the process of update
         app.textures[i].syncIndex = app.syncIndex;
       } // else:  // Dirty and in the process of update
     }
   }
-  if(needsUpdate) { if(app.verbose) SDL_Log("Texture Loaded A-sync, updating");
+  if(needsUpdate) {
+    SDL_Log("updateTextures: updating descriptor set syncIndex=%d textures.length=%d", app.syncIndex, app.textures.length);
     app.updateDescriptorSet(app.shaders, app.sets[Stage.RENDER], app.syncIndex);
   }
 }

--- a/src/engine/threading.d
+++ b/src/engine/threading.d
@@ -100,7 +100,7 @@ void checkAsync(ref App app) {
     VkResult result = vkGetFenceStatus(app.device, app.textures.cmdBuffer.fence);
     if (result == VK_SUCCESS) {
       app.textures.transfer = false;
-      app.mapTextures();
+      //app.mapTextures();
     }
   }
 }

--- a/src/engine/uniforms.d
+++ b/src/engine/uniforms.d
@@ -91,17 +91,4 @@ void updateRenderUBO(ref App app, Shader[] shaders, uint syncIndex) {
   }
 }
 
-void writeUniformBuffer(ref App app, ref VkWriteDescriptorSet[] write, Descriptor descriptor, VkDescriptorSet[] dst, ref VkDescriptorBufferInfo[] bufferInfos, uint syncIndex = 0){
-  if(app.verbose) SDL_Log("writeUniformBuffer[%s] #%d", toStringz(descriptor.base), syncIndex);
-  bufferInfos ~= VkDescriptorBufferInfo(app.ubos[descriptor.base].buffers[syncIndex], 0, descriptor.bytes);
-  VkWriteDescriptorSet set = {
-    sType: VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET,
-    dstSet: dst[syncIndex],
-    dstBinding: descriptor.binding,
-    dstArrayElement: 0,
-    descriptorType: VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
-    descriptorCount: 1,
-    pBufferInfo: &bufferInfos[($-1)]
-  };
-  write ~= set;
-}
+

--- a/src/engine/validation.d
+++ b/src/engine/validation.d
@@ -14,7 +14,7 @@ PFN_vkCmdEndDebugUtilsLabelEXT      vkCmdEndDebugUtilsLabel;
 extern(C) uint debugCallback(VkDebugReportFlagsEXT flags, VkDebugReportObjectTypeEXT objectType, uint64_t object, 
                              size_t location, int32_t messageCode, const char* pLayerPrefix, const char* pMessage, void* pUserData) {
     SDL_Log("[debugCallback] Debug report from ObjectType: %d\nMessage %d: %s\n", objectType, messageCode, pMessage);
-//    if(flags & VK_DEBUG_REPORT_ERROR_BIT_EXT) { assert(false, "Validation error"); }
+    if(flags & VK_DEBUG_REPORT_ERROR_BIT_EXT) { assert(false, "Validation error"); }
     return VK_FALSE;
 }
 

--- a/src/objects/geometry.d
+++ b/src/objects/geometry.d
@@ -327,6 +327,16 @@ void draw(T)(ref App app, ref T object, size_t i) {
   if(!object.isBuffered()) return;
   if(app.trace) SDL_Log("DRAW: %d instances", object.instances.length);
 
+  foreach(ref inst; object.instances) {
+    for(uint m = inst.meshdef[0]; m < inst.meshdef[1]; m++) {
+      if(m < app.meshInfo.length) {
+        auto mesh = app.meshInfo[m];
+        SDL_Log("DRAW[%s] mesh[%d] tid=%d nid=%d oid=%d textures=%d", 
+                toStringz(object.name()), m, mesh.tid, mesh.nid, mesh.oid, cast(uint)app.textures.length);
+      }
+    }
+  }
+
   VkDeviceSize[] offsets = [0];
 
   vkCmdBindVertexBuffers(app.renderBuffers[i], VERTEX, 1, &object.vertexBuffer.vb, &offsets[0]);

--- a/src/objects/geometry.d
+++ b/src/objects/geometry.d
@@ -9,6 +9,7 @@ import buffer : destroyGeometryBuffers, nameGeometryBuffer, toGPU;
 import boundingbox : computeBoundingBox;
 import matrix : position, transpose, translate, rotate, scale, inverse;
 import textures : idx;
+import mesh : logMesh;
 import vector : vSub, vAdd, dot, vMul, cross, normalize, euclidean;
 
 /** An instance of a Geometry
@@ -94,6 +95,13 @@ struct Geometries {
   Geometry[] array;
   bool loaded = false; /// Are we loading a texture a-sync ?
   alias array this;
+}
+
+void logDraw(T)(ref App app, ref T object) {
+  if(!app.trace) return;
+  foreach(ref inst; object.instances) {
+    for(uint m = inst.meshdef[0]; m < inst.meshdef[1]; m++) { if(m < app.meshInfo.length){ logMesh(m, app.meshInfo[m], toStringz(object.name())); } }
+  }
 }
 
 void bufferGeometries(ref App app, ref VkCommandBuffer cmd){
@@ -325,17 +333,7 @@ void computeTangents(T)(ref T geometry, bool verbose = false) {
 /** Render a Geometry to app.renderBuffers[i] */
 void draw(T)(ref App app, ref T object, size_t i) {
   if(!object.isBuffered()) return;
-  if(app.trace) SDL_Log("DRAW: %d instances", object.instances.length);
-
-  foreach(ref inst; object.instances) {
-    for(uint m = inst.meshdef[0]; m < inst.meshdef[1]; m++) {
-      if(m < app.meshInfo.length) {
-        auto mesh = app.meshInfo[m];
-        SDL_Log("DRAW[%s] mesh[%d] tid=%d nid=%d oid=%d textures=%d", 
-                toStringz(object.name()), m, mesh.tid, mesh.nid, mesh.oid, cast(uint)app.textures.length);
-      }
-    }
-  }
+  app.logDraw(object);
 
   VkDeviceSize[] offsets = [0];
 


### PR DESCRIPTION
Enable VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT for all array bindings in DescriptorLayoutBuilder, fixing validation layer errors when texture arrays are not fully populated. Fix texureSampler typo in descriptor name lookup. Add trace logging to writeTextureSampler, createSSBO and updateSSBO. Update dub.json dependencies, fix Linux compilation, and correct shader structures for updated binding layout.