### PR TITLE
Fix Android Vulkan crashes: thread safety, GPU sync, and async texture upload

### DIFF
--- a/src/engine/assimp/animation.d
+++ b/src/engine/assimp/animation.d
@@ -72,10 +72,10 @@ void calculateGlobalTransform(ref App app, ref Geometry obj, const Node node, co
 
 /** load all animations from aiScene*
  */
-Animation[] loadAnimations(ref App app, aiScene* scene, const OpenAsset asset) {
+Animation[] loadAnimations(aiScene* scene, const OpenAsset asset, bool verbose = false) {
   Animation[] animations;
   animations.length = scene.mNumAnimations;
-  if(app.verbose) SDL_Log("Processing %u animations...", scene.mNumAnimations);
+  if(verbose) SDL_Log("Processing %u animations...", scene.mNumAnimations);
   for (uint i = 0; i < scene.mNumAnimations; i++) {
     auto aiAnim = scene.mAnimations[i];
     Animation anim;
@@ -83,7 +83,7 @@ Animation[] loadAnimations(ref App app, aiScene* scene, const OpenAsset asset) {
     anim.duration = aiAnim.mDuration;
     anim.ticksPerSecond = aiAnim.mTicksPerSecond != 0 ? aiAnim.mTicksPerSecond : 24.0;
 
-    if (app.verbose) {
+    if (verbose) {
       SDL_Log("  Animation %u: %s (Duration: %.2f ticks, Ticks/Sec: %.2f)", i, toStringz(anim.name), anim.duration, anim.ticksPerSecond);
       SDL_Log("  %u animation channels", aiAnim.mNumChannels);
     }
@@ -93,7 +93,7 @@ Animation[] loadAnimations(ref App app, aiScene* scene, const OpenAsset asset) {
       NodeAnimation nodeAnim;
       string nodeName = asset.nodeName(name(aiNodeAnim.mNodeName));
 
-      if (app.trace) {
+      if (verbose) {
         SDL_Log("    Node Channel %u for '%s'", j, toStringz(nodeName));
         SDL_Log("      Position Keys: %u", aiNodeAnim.mNumPositionKeys);
         SDL_Log("      Rotation Keys: %u", aiNodeAnim.mNumRotationKeys);

--- a/src/engine/assimp/bone.d
+++ b/src/engine/assimp/bone.d
@@ -61,3 +61,18 @@ void updateBoneOffsets(App app, uint syncIndex) {
   app.buffers["BoneMatrices"].dirty[syncIndex] = true;
 }
 
+void mergeBones(ref App app, ref OpenAsset obj) {
+  uint[uint] indexMap;
+  foreach(boneName, ref bone; obj.bones) {
+    if(!(boneName in app.bones)) {
+      uint newIndex = cast(uint)app.bones.length;
+      indexMap[bone.index] = newIndex;
+      bone.index = newIndex;
+      app.bones[boneName] = bone;
+    } else { indexMap[bone.index] = app.bones[boneName].index; }
+  }
+  foreach(ref v; obj.vertices) {
+    for(uint i = 0; i < v.bones.length; i++) { if(v.bones[i] in indexMap) v.bones[i] = indexMap[v.bones[i]]; }
+  }
+}
+

--- a/src/engine/assimp/bone.d
+++ b/src/engine/assimp/bone.d
@@ -54,7 +54,7 @@ BoneWeights loadBoneWeights(OpenAsset asset, aiMesh* mesh, ref Bone[string] glob
 void updateBoneOffsets(App app, uint syncIndex) {
   ulong t = SDL_GetTicks() - app.time[STARTUP];
   foreach(ref obj; app.objects) {
-    if(obj.animations.length > 0) {
+    if(obj.animations.length > 0 && obj.rootnode.name !is null) {
       double cT = calculateCurrentTick(t, obj.animations[obj.animation].ticksPerSecond, obj.animations[obj.animation].duration);
       app.calculateGlobalTransform(obj, obj.rootnode, Matrix(), cT);
     }

--- a/src/engine/assimp/bone.d
+++ b/src/engine/assimp/bone.d
@@ -25,8 +25,7 @@ struct Bone {
 
 alias float[uint][string] BoneWeights;
 
-/** loadBoneWeights
- * TODO: Should actually not write to globalBones (tread safety issue with threading.d)
+/** loadBoneWeights - writes to asset-local bones, merged into app.bones on main thread
  */
 BoneWeights loadBoneWeights(OpenAsset asset, aiMesh* mesh, ref Bone[string] globalBones, Matrix pTransform) {
   BoneWeights weights;

--- a/src/engine/assimp/material.d
+++ b/src/engine/assimp/material.d
@@ -38,22 +38,14 @@ float[4] getMaterialColor(aiMaterial* material, aiColorType type = aiColorType.D
   return([color.r, color.g, color.b, color.a]);
 }
 
-int getTexture(T)(ref App app, T object, uint materialIndex, aiTextureType type = aiTextureType_DIFFUSE){
-  if (type in object.materials[materialIndex].textures) {
-    int index = idx(app.textures, object.materials[materialIndex].textures[type]);
-    return(index);
-  }
-  return(-1);
-}
-
-int getChannel(T)(ref App app, T object, uint materialIndex, aiTextureType type = aiTextureType_DIFFUSE) {
+int getChannel(T)(T object, uint materialIndex, aiTextureType type = aiTextureType_DIFFUSE) {
   if (type in object.materials[materialIndex].textures) {
     return(object.materials[materialIndex].textures[type].channel);
   }
   return(0);
 }
 
-Material[] loadMaterials(ref App app, aiScene* scene, const(char)* path){
+Material[] loadMaterials(aiScene* scene, const(char)* path){
   Material[] materials;
   for(uint i = 0; i < scene.mNumMaterials; i++) {
     aiMaterial* material = scene.mMaterials[i];

--- a/src/engine/assimp/mesh.d
+++ b/src/engine/assimp/mesh.d
@@ -44,15 +44,15 @@ void updateMeshInfo(ref App app) {
   if(needsUpdate) app.buffers["MeshMatrices"].dirty[] = true; // Update all syncIndexes
 }
 
-string loadMesh(ref App app, aiMesh* mesh, ref OpenAsset asset, const Matrix gTransform) {
-  if (app.verbose) {
+string loadMesh(aiMesh* mesh, ref OpenAsset asset, const Matrix gTransform, bool verbose = false) {
+  if (verbose) {
     SDL_Log("Mesh: %s", toStringz(name(mesh.mName)));
     SDL_Log(" - %u vertices, %u faces, %u bones", mesh.mNumVertices, mesh.mNumFaces, mesh.mNumBones);
     SDL_Log(" - %u / %u material", mesh.mMaterialIndex, asset.materials.length);
   }
   // Vertex offset, load texture information,  bone weight, and normal matrix
   size_t vOff = asset.vertices.length;
-  auto channel = app.getChannel(asset, mesh.mMaterialIndex, aiTextureType_DIFFUSE);
+  auto channel = getChannel(asset, mesh.mMaterialIndex, aiTextureType_DIFFUSE);
   auto weights = asset.loadBoneWeights(mesh, asset.bones, gTransform);
   auto normMatrix = gTransform.inverse().transpose();
 

--- a/src/engine/assimp/mesh.d
+++ b/src/engine/assimp/mesh.d
@@ -53,7 +53,7 @@ string loadMesh(ref App app, aiMesh* mesh, ref OpenAsset asset, const Matrix gTr
   // Vertex offset, load texture information,  bone weight, and normal matrix
   size_t vOff = asset.vertices.length;
   auto channel = app.getChannel(asset, mesh.mMaterialIndex, aiTextureType_DIFFUSE);
-  auto weights = asset.loadBoneWeights(mesh, app.bones, gTransform);
+  auto weights = asset.loadBoneWeights(mesh, asset.bones, gTransform);
   auto normMatrix = gTransform.inverse().transpose();
 
   // TODO first create a Material definition for the object => add to app.materials
@@ -77,7 +77,7 @@ string loadMesh(ref App app, aiMesh* mesh, ref OpenAsset asset, const Matrix gTr
     if (mesh.mTangents) {
       asset.vertices[gIdx].tangent = [mesh.mTangents[vIdx].x, mesh.mTangents[vIdx].y, mesh.mTangents[vIdx].z];
     }
-    asset.assignBoneWeight(gIdx, weights, vIdx, app.bones);
+    asset.assignBoneWeight(gIdx, weights, vIdx, asset.bones);
   }
 
   for (size_t f = 0; f < mesh.mNumFaces; f++) {  // Load faces to indices

--- a/src/engine/assimp/meta.d
+++ b/src/engine/assimp/meta.d
@@ -14,7 +14,7 @@ struct MetaData {
   double scalefactor;
 }
 
-MetaData loadMetaData(const App app, aiScene* scene) {
+MetaData loadMetaData(aiScene* scene, bool verbose = false) {
   aiMetadata* mData = scene.mMetaData;
   MetaData meta;
   for (uint i = 0; i < mData.mNumProperties; ++i) {
@@ -29,7 +29,7 @@ MetaData loadMetaData(const App app, aiScene* scene) {
     if (key == "CoordAxisSign") { meta.coordAxis[1] = *cast(int*)(mData.mValues[i].mData); }
     if (key == "UnitScaleFactor") { meta.scalefactor = *cast(float*)(mData.mValues[i].mData); }
   }
-  if (app.verbose) {
+  if (verbose) {
     SDL_Log(toStringz(format("MetaData UP: %s", meta.upAxis)));
     SDL_Log(toStringz(format("MetaData Front: %s", meta.frontAxis)));
     SDL_Log(toStringz(format("MetaData Coord: %s", meta.coordAxis)));

--- a/src/engine/assimp/node.d
+++ b/src/engine/assimp/node.d
@@ -17,19 +17,19 @@ struct Node {
   string[] meshes;
 }
 
-Node loadNode(ref App app, ref OpenAsset asset, aiScene* scene, aiNode* node, const Matrix pTransform, uint lvl = 0) {
+Node loadNode(ref OpenAsset asset, aiScene* scene, aiNode* node, const Matrix pTransform, uint lvl = 0) {
   Node n = Node(asset.nodeName(name(node.mName)), lvl, toMatrix(node.mTransformation));
   Matrix gTransform = pTransform.multiply(n.transform);
 
   for (uint i = 0; i < node.mNumMeshes; i++){
     aiMesh* mesh = scene.mMeshes[node.mMeshes[i]];
     if(name(mesh.mName) == "Cube") continue;
-    n.meshes ~= app.loadMesh(mesh, asset, gTransform);
+    n.meshes ~= loadMesh(mesh, asset, gTransform);
   }
 
   n.children.length = node.mNumChildren;
   for (uint i = 0; i < node.mNumChildren; ++i) {
-    n.children[i] = app.loadNode(asset, scene, node.mChildren[i], gTransform, lvl+1);
+    n.children[i] = loadNode(asset, scene, node.mChildren[i], gTransform, lvl+1);
   }
   return(n);
 }

--- a/src/engine/buffer.d
+++ b/src/engine/buffer.d
@@ -94,6 +94,18 @@ void updateBuffer(ref App app, ref GeometryBuffer buffer, VkCommandBuffer cmdBuf
   if(app.trace) SDL_Log("updateBuffer");
   VkBufferCopy copyRegion = { size : buffer.size };
   vkCmdCopyBuffer(cmdBuffer, buffer.sb, buffer.vb, 1, &copyRegion);
+
+  VkBufferMemoryBarrier barrier = {
+    sType: VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER,
+    srcAccessMask: VK_ACCESS_TRANSFER_WRITE_BIT,
+    dstAccessMask: VK_ACCESS_VERTEX_ATTRIBUTE_READ_BIT | VK_ACCESS_INDEX_READ_BIT,
+    srcQueueFamilyIndex: VK_QUEUE_FAMILY_IGNORED,
+    dstQueueFamilyIndex: VK_QUEUE_FAMILY_IGNORED,
+    buffer: buffer.vb,
+    offset: 0,
+    size: VK_WHOLE_SIZE
+  };
+  vkCmdPipelineBarrier(cmdBuffer, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_VERTEX_INPUT_BIT, 0, 0, null, 1, &barrier, 0, null);
 }
 
 void copyBufferToImage(ref App app, VkCommandBuffer commandBuffer, VkBuffer buffer, VkImage image, uint width, uint height) {

--- a/src/engine/buffer.d
+++ b/src/engine/buffer.d
@@ -95,17 +95,12 @@ void updateBuffer(ref App app, ref GeometryBuffer buffer, VkCommandBuffer cmdBuf
   VkBufferCopy copyRegion = { size : buffer.size };
   vkCmdCopyBuffer(cmdBuffer, buffer.sb, buffer.vb, 1, &copyRegion);
 
-  VkBufferMemoryBarrier barrier = {
-    sType: VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER,
+  VkMemoryBarrier barrier = {
+    sType: VK_STRUCTURE_TYPE_MEMORY_BARRIER,
     srcAccessMask: VK_ACCESS_TRANSFER_WRITE_BIT,
     dstAccessMask: VK_ACCESS_VERTEX_ATTRIBUTE_READ_BIT | VK_ACCESS_INDEX_READ_BIT,
-    srcQueueFamilyIndex: VK_QUEUE_FAMILY_IGNORED,
-    dstQueueFamilyIndex: VK_QUEUE_FAMILY_IGNORED,
-    buffer: buffer.vb,
-    offset: 0,
-    size: VK_WHOLE_SIZE
   };
-  vkCmdPipelineBarrier(cmdBuffer, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_VERTEX_INPUT_BIT, 0, 0, null, 1, &barrier, 0, null);
+  vkCmdPipelineBarrier(cmdBuffer, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_VERTEX_INPUT_BIT, 0, 1, &barrier, 0, null, 0, null);
 }
 
 void copyBufferToImage(ref App app, VkCommandBuffer commandBuffer, VkBuffer buffer, VkImage image, uint width, uint height) {

--- a/src/engine/commands.d
+++ b/src/engine/commands.d
@@ -22,6 +22,7 @@ void recordSceneCommandBuffer(ref App app, Shader[] shaders, uint syncIndex) {
     sType: VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO,
     pInheritanceInfo: null
   };
+  enforceVK(vkResetCommandBuffer(cmd, 0)); // Reset for recording
   enforceVK(vkBeginCommandBuffer(cmd, &beginInfo));
   app.nameVulkanObject(cmd, toStringz(format("[COMMANDBUFFER] Render %d", syncIndex)), VK_OBJECT_TYPE_COMMAND_BUFFER);
 
@@ -72,6 +73,7 @@ void recordPostCommandBuffer(ref App app, uint syncIndex) {
     sType: VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO,
     pInheritanceInfo: null
   };
+  enforceVK(vkResetCommandBuffer(cmd, 0)); // Reset for recording
   enforceVK(vkBeginCommandBuffer(cmd, &beginInfo));
   app.nameVulkanObject(cmd, toStringz(format("[COMMANDBUFFER] Post %d", syncIndex)), VK_OBJECT_TYPE_COMMAND_BUFFER);
 

--- a/src/engine/events.d
+++ b/src/engine/events.d
@@ -45,8 +45,8 @@ void handleTouchEvents(ref App app, const SDL_Event event) {
   }
   if(event.type == SDL_EVENT_FINGER_MOTION) {
     if(e.fingerID == app.camera.fingerIDs[1]) {
-      if (e.dy > 0 && app.camera.distance <= 30.0f) app.camera.distance -= 0.2f;
-      if (e.dy < 0 && app.camera.distance >=  2.0f) app.camera.distance += 0.2f;
+      if (e.dy > 0 && app.camera.distance <= 60.0f) app.camera.distance += 0.25f;
+      if (e.dy < 0 && app.camera.distance >=  2.0f) app.camera.distance -= 0.25f;
     } else if(e.fingerID == app.camera.fingerIDs[0]) {
       app.camera.drag(-e.dx * 0.5 * app.camera.width, e.dy * 0.25 * app.camera.height);
     }

--- a/src/engine/events.d
+++ b/src/engine/events.d
@@ -45,8 +45,8 @@ void handleTouchEvents(ref App app, const SDL_Event event) {
   }
   if(event.type == SDL_EVENT_FINGER_MOTION) {
     if(e.fingerID == app.camera.fingerIDs[1]) {
-      if (e.dy > 0 && app.camera.distance <= 30.0f) app.camera.distance += 0.2f;
-      if (e.dy < 0 && app.camera.distance >=  2.0f) app.camera.distance -= 0.2f;
+      if (e.dy > 0 && app.camera.distance <= 30.0f) app.camera.distance -= 0.2f;
+      if (e.dy < 0 && app.camera.distance >=  2.0f) app.camera.distance += 0.2f;
     } else if(e.fingerID == app.camera.fingerIDs[0]) {
       app.camera.drag(-e.dx * 0.5 * app.camera.width, e.dy * 0.25 * app.camera.height);
     }
@@ -180,8 +180,7 @@ extern(C) bool sdlEventsFilter(void* userdata, SDL_Event* event) {
 // Immediate events to handle by the application
 void handleApp(ref App app, const SDL_Event e) {
   if(e.type == SDL_EVENT_WILL_ENTER_BACKGROUND){
-    SDL_Log("Suspending.");
-    SDL_Log("Wait on device idle & swapchain deletion queue");
+    SDL_Log("Suspending, wait on device idle & swapchain deletion queue");
     enforceVK(vkDeviceWaitIdle(app.device));
     app.swapDeletionQueue.flush(); // Frame deletion queue, flushes the buffers
 
@@ -189,8 +188,7 @@ void handleApp(ref App app, const SDL_Event e) {
     saveSettings();
   }
   if(e.type == SDL_EVENT_DID_ENTER_BACKGROUND){
-    SDL_Log("Completely in background.");
-    SDL_Log("Shutdown ImGui");
+    SDL_Log("Completely in background, shutdown ImGui...");
     app.isImGuiInitialized = false;
     ImGui_ImplVulkan_Shutdown();
     ImGui_ImplSDL3_Shutdown();

--- a/src/engine/frame.d
+++ b/src/engine/frame.d
@@ -36,7 +36,8 @@ void renderFrame(ref App app) {
 
   if(app.trace) SDL_Log("Phase 1: Aquire the image");
   auto err = vkAcquireNextImageKHR(app.device, app.swapChain, uint.max, imageAcquired, null, &app.frameIndex);
-  if (err == VK_ERROR_OUT_OF_DATE_KHR || err == VK_SUBOPTIMAL_KHR) { app.rebuild = true; return; }
+  if (err == VK_ERROR_OUT_OF_DATE_KHR || err == VK_SUBOPTIMAL_KHR) app.rebuild = true;
+  if (err == VK_ERROR_OUT_OF_DATE_KHR) return;
   if (err != VK_SUBOPTIMAL_KHR) enforceVK(err);
   if(app.trace) SDL_Log("Phase 1: Aquired %d", app.frameIndex);
   VkSemaphore renderComplete = app.renderComplete[app.frameIndex];

--- a/src/engine/imgui.d
+++ b/src/engine/imgui.d
@@ -156,6 +156,7 @@ void recordImGuiCommandBuffer(ref App app, uint syncIndex) {
     sType : VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO,
     flags : VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT
   };
+  enforceVK(vkResetCommandBuffer(cmd, 0)); // Reset for recording
   enforceVK(vkBeginCommandBuffer(cmd, &commandBufferInfo));
   app.nameVulkanObject(cmd, toStringz(format("[COMMANDBUFFER] ImGui %d", syncIndex)), VK_OBJECT_TYPE_COMMAND_BUFFER);
 

--- a/src/engine/shadow.d
+++ b/src/engine/shadow.d
@@ -246,9 +246,9 @@ void recordShadowCommandBuffer(ref App app, uint syncIndex) {
   app.updateDescriptorData(app.shadows.shaders, app.shadows.commands, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, syncIndex);
   popLabel(cmd);
 
-  pushLabel(cmd, "Objects Buffering", Colors.lightgray);
+  /*pushLabel(cmd, "Objects Buffering", Colors.lightgray);
   app.bufferGeometries(cmd);
-  popLabel(cmd);
+  popLabel(cmd); */
 
   pushLabel(cmd, "Shadow Loop", Colors.lightgray);
   vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, 

--- a/src/engine/shadow.d
+++ b/src/engine/shadow.d
@@ -229,12 +229,12 @@ void updateShadowMapUBO(ref App app, Shader[] shaders, uint syncIndex) {
 
 void recordShadowCommandBuffer(ref App app, uint syncIndex) {
   auto cmd = app.shadows.commands[syncIndex];
-  vkResetCommandBuffer(cmd, 0); // Reset for recording
 
   VkCommandBufferBeginInfo beginInfo = {
       sType: VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO,
       pInheritanceInfo: null
   };
+  enforceVK(vkResetCommandBuffer(cmd, 0)); // Reset for recording
   enforceVK(vkBeginCommandBuffer(cmd, &beginInfo));
   app.nameVulkanObject(cmd, toStringz(format("[COMMANDBUFFER] Shadow %d", syncIndex)), VK_OBJECT_TYPE_COMMAND_BUFFER);
 

--- a/src/engine/sync.d
+++ b/src/engine/sync.d
@@ -67,12 +67,12 @@ void insertWriteBarrier(ref VkCommandBuffer cmdBuffer, VkBuffer buffer, VkDevice
   VkBufferMemoryBarrier writeBarrier = {
       sType : VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER,
       srcAccessMask : VK_ACCESS_SHADER_WRITE_BIT, // Previous stage (e.g., compute shader writing to pOut)
-      dstAccessMask : VK_ACCESS_TRANSFER_READ_BIT,  // Access for the copy operation
+      dstAccessMask : VK_ACCESS_SHADER_READ_BIT,  // Access for the copy operation
       buffer : buffer,
       size : size                    // Size of the affected region
   };
 
-  vkCmdPipelineBarrier(cmdBuffer, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, null, 1, &writeBarrier, 0, null);
+  vkCmdPipelineBarrier(cmdBuffer, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, VK_PIPELINE_STAGE_VERTEX_SHADER_BIT, 0, 0, null, 1, &writeBarrier, 0, null);
 }
 
 void insertReadBarrier(ref VkCommandBuffer cmdBuffer, VkBuffer buffer, VkDeviceSize size = VK_WHOLE_SIZE) {

--- a/src/engine/textures.d
+++ b/src/engine/textures.d
@@ -34,10 +34,10 @@ struct Texture {
 }
 
 struct Textures {
-  Texture[] textures;             /// Textures
-  bool loaded = false;            /// Are we loading a texture a-sync ?
-  bool transfer = false;          /// Are we currently using the transfer queue for uploading & transitioning ?
-  SingleTimeCommand cmdBuffer;    /// A-Sync single time command buffer
+  Texture[] textures;                         /// Textures
+  bool loaded = false;                        /// Are we loading a texture a-sync ?
+  bool transfer = false;                      /// Are we currently using the transfer queue for uploading & transitioning ?
+  SingleTimeCommand cmdBuffer;                /// A-Sync single time command buffer
   alias textures this;
 }
 
@@ -84,7 +84,7 @@ SDL_Surface* createDummySDLSurface() {
   return(besthit);
 }
 
-void transferTextureAsync(ref App app, ref Texture texture){
+void transferTextureAsync(ref App app, ref Texture texture) {
   app.textures.cmdBuffer = app.beginSingleTimeCommands(app.transferPool, true);
   app.toGPU(app.textures.cmdBuffer, texture);
   vkEndCommandBuffer(app.textures.cmdBuffer);

--- a/src/engine/textures.d
+++ b/src/engine/textures.d
@@ -9,7 +9,6 @@ import buffer : createBuffer, copyBufferToImage;
 import commands : beginSingleTimeCommands, endSingleTimeCommands;
 import descriptor : createDescriptorSet, updateDescriptorSet;
 import glyphatlas : createFontTexture;
-import material : getTexture;
 import images : nameImageBuffer, imageSize, createImage, deAllocate, transitionImageLayout;
 import io : dir;
 import swapchain : createImageView;
@@ -101,6 +100,14 @@ void transferTextureAsync(ref App app, ref Texture texture){
 
 void mapTextures(ref App app){
   for(uint i = 0; i < app.objects.length; i++) { app.mapTextures(app.objects[i]); }
+}
+
+int getTexture(T)(ref App app, T object, uint materialIndex, aiTextureType type = aiTextureType_DIFFUSE){
+  if (type in object.materials[materialIndex].textures) {
+    int index = idx(app.textures, object.materials[materialIndex].textures[type]);
+    return(index);
+  }
+  return(-1);
 }
 
 void mapTextures(ref App app, ref Geometry object){

--- a/src/engine/textures.d
+++ b/src/engine/textures.d
@@ -33,11 +33,15 @@ struct Texture {
   alias buffer this;
 }
 
+struct PendingTexture {
+  Texture texture;
+  SingleTimeCommand cmdBuffer;
+}
+
 struct Textures {
   Texture[] textures;                         /// Textures
+  PendingTexture[] pending;                   /// Textures submitted to GPU but not yet confirmed ready
   bool loaded = false;                        /// Are we loading a texture a-sync ?
-  bool transfer = false;                      /// Are we currently using the transfer queue for uploading & transitioning ?
-  SingleTimeCommand cmdBuffer;                /// A-Sync single time command buffer
   alias textures this;
 }
 
@@ -85,17 +89,17 @@ SDL_Surface* createDummySDLSurface() {
 }
 
 void transferTextureAsync(ref App app, ref Texture texture) {
-  app.textures.cmdBuffer = app.beginSingleTimeCommands(app.transferPool, true);
-  app.toGPU(app.textures.cmdBuffer, texture);
-  vkEndCommandBuffer(app.textures.cmdBuffer);
+  SingleTimeCommand cmdBuffer = app.beginSingleTimeCommands(app.transferPool, true);
+  app.toGPU(cmdBuffer, texture);
+  vkEndCommandBuffer(cmdBuffer);
   VkSubmitInfo submitInfo = {
     sType: VK_STRUCTURE_TYPE_SUBMIT_INFO,
     commandBufferCount: 1,
-    pCommandBuffers: &app.textures.cmdBuffer.commands,
+    pCommandBuffers: &cmdBuffer.commands,
   };
-  app.nameVulkanObject(app.textures.cmdBuffer.fence, toStringz(format("[FENCE] %s", texture.path)), VK_OBJECT_TYPE_FENCE);
-  enforceVK(vkQueueSubmit(app.transfer, 1, &submitInfo, app.textures.cmdBuffer.fence)); // Submit to the transfer queue
-  app.textures ~= texture;
+  app.nameVulkanObject(cmdBuffer.fence, toStringz(format("[FENCE] %s", texture.path)), VK_OBJECT_TYPE_FENCE);
+  enforceVK(vkQueueSubmit(app.transfer, 1, &submitInfo, cmdBuffer.fence));
+  app.textures.pending ~= PendingTexture(texture, cmdBuffer);
 }
 
 void mapTextures(ref App app){
@@ -121,24 +125,21 @@ void mapTextures(ref App app, ref Geometry object){
 
 void updateTextures(ref App app) {
   bool needsUpdate = false;
-  for(uint i = 0; i < app.textures.length; i++) { 
-    if(app.textures[i].dirty) {
+  size_t nPending = app.textures.pending.length;
+  foreach(ref texture; app.textures) {
+    if(texture.dirty) {
       needsUpdate = true;
-      if(app.trace) {
-        SDL_Log("updateTextures: syncIndex=%d texture[%d].syncIndex=%d transfer=%d", app.syncIndex, i, app.textures[i].syncIndex, app.textures.transfer);
-      }
-      if(app.textures[i].syncIndex == app.syncIndex) { // We are round, we updated all the descriptors for each Frame in Flight
-        app.textures[i].dirty = false;
-        app.textures[i].syncIndex = -1;
+      if(app.trace) { SDL_Log("updateTextures: syncIndex=%d texture.syncIndex=%d pending=%d", app.syncIndex, texture.syncIndex, nPending); }
+      if(texture.syncIndex == app.syncIndex) {
+        texture.dirty = false;
+        texture.syncIndex = -1;
         app.mapTextures();
         needsUpdate = false;
-      } else if(app.textures[i].syncIndex == -1) { // Dirty and not in the process of update
-        app.textures[i].syncIndex = app.syncIndex;
-      } // else:  // Dirty and in the process of update
+      } else if(texture.syncIndex == -1) { texture.syncIndex = app.syncIndex; }
     }
   }
   if(needsUpdate) {
-    if(app.trace) SDL_Log("updateTextures: updating descriptor set syncIndex=%d textures.length=%d", app.syncIndex, app.textures.length);
+    if(app.trace) SDL_Log("updateTextures -> updateDescriptorSet (syncIndex=%d textures.length=%d)", app.syncIndex, app.textures.length);
     app.updateDescriptorSet(app.shaders, app.sets[Stage.RENDER], app.syncIndex);
   }
 }

--- a/src/engine/threading.d
+++ b/src/engine/threading.d
@@ -91,19 +91,21 @@ void checkAsync(ref App app) {
     app.objects ~= obj;
     app.mapTextures(app.objects[($-1)]);
   });
-  if(!app.textures.transfer) {
-    receiveTimeout(dur!"msecs"(-1), (immutable(Texture) message, Tid tid) {
-      app.concurrency.workers[tid] = false;
-      Texture texture = cast(Texture)message;
-      app.textures.transfer = true;
-      app.transferTextureAsync(texture);
-      app.mainDeletionQueue.add((){ app.deAllocate(texture); });
-    });
-  }else{
-    VkResult result = vkGetFenceStatus(app.device, app.textures.cmdBuffer.fence);
-    if (result == VK_SUCCESS) {
-      app.textures.transfer = false;
-      //app.mapTextures();
-    }
+  // Accept any incoming texture transfers
+  receiveTimeout(dur!"msecs"(-1), (immutable(Texture) message, Tid tid) {
+    app.concurrency.workers[tid] = false;
+    Texture texture = cast(Texture)message;
+    app.transferTextureAsync(texture);
+    app.mainDeletionQueue.add((){ app.deAllocate(texture); });
+  });
+  // Check all pending texture transfers; promote to app.textures once GPU is done
+  size_t i = 0;
+  while(i < app.textures.pending.length) {
+    if(vkGetFenceStatus(app.device, app.textures.pending[i].cmdBuffer.fence) == VK_SUCCESS) {
+      app.textures ~= app.textures.pending[i].texture;
+      app.textures.pending = app.textures.pending.remove(i);
+      app.mapTextures();
+    } else { i++; }
   }
 }
+

--- a/src/engine/threading.d
+++ b/src/engine/threading.d
@@ -30,19 +30,17 @@ class TaskThread : Thread {
     while (active) {
       receiveTimeout(dur!"msecs"(250),
         (string path) {
-          if(verbose) SDL_Log("Received path: %s", toStringz(extension(path)));
-          if(path.isTexture()){
+          if (verbose) SDL_Log("Received path: %s", toStringz(extension(path)));
+          if (path.isTexture()) {
             auto fp = fixPath(toStringz(path));
             auto surface = IMG_Load(fp);
             if (SDL_GetPixelFormatDetails(surface.format).bits_per_pixel != 32) { surface.toRGBA(verbose); }
-            auto t = Texture(path, surface.w, surface.h, surface);
-            auto immutableT = cast(immutable)t;
-            main.send(immutableT, mytid);
-          }else if(path.isOpenAsset()){
-            auto g = loadOpenAsset(toStringz(path));
-            auto immutableG = cast(immutable)g;
-            main.send(immutableG, mytid);
-          }else{ main.send("Unknown file", mytid); }
+            auto texture = cast(immutable(Texture))Texture(path, surface.w, surface.h, surface);
+            main.send(texture, mytid);
+          } else if(path.isOpenAsset()) {
+            auto openasset = cast(immutable(OpenAsset))loadOpenAsset(toStringz(path), verbose);
+            main.send(openasset, mytid);
+          } else { main.send("Unknown file", mytid); }
         }
       );
       SDL_Delay(10);

--- a/src/engine/threading.d
+++ b/src/engine/threading.d
@@ -12,34 +12,34 @@ import images : deAllocate;
 import textures: isTexture, mapTextures, transferTextureAsync, toRGBA;
 
 class TaskThread : Thread {
-  private App* app;
-  private bool active = true;
   private Tid main;
   private Tid mytid;
+  private bool verbose = false;
+  private bool active = true;
 
-  this(App* a, Tid id) {
-    this.app = a;
+  this(Tid id, bool verbose = false) {
     this.main = id;
+    this.verbose = verbose;
     this.isDaemon(true);
     super(&run);
   }
 
-  void run() { if(app.verbose) SDL_Log("Worker spawned: %p", thisTid);
+  void run() { if(verbose) SDL_Log("Worker spawned: %p", thisTid);
     mytid = thisTid();
     main.send(mytid);
-    while(active){
+    while (active) {
       receiveTimeout(dur!"msecs"(250),
         (string path) {
-          if(app.verbose) SDL_Log("Received path: %s", toStringz(extension(path)));
+          if(verbose) SDL_Log("Received path: %s", toStringz(extension(path)));
           if(path.isTexture()){
             auto fp = fixPath(toStringz(path));
             auto surface = IMG_Load(fp);
-            if (SDL_GetPixelFormatDetails(surface.format).bits_per_pixel != 32) { surface.toRGBA((*app).verbose); }
+            if (SDL_GetPixelFormatDetails(surface.format).bits_per_pixel != 32) { surface.toRGBA(verbose); }
             auto t = Texture(path, surface.w, surface.h, surface);
             auto immutableT = cast(immutable)t;
             main.send(immutableT, mytid);
           }else if(path.isOpenAsset()){
-            auto g = (*app).loadOpenAsset(toStringz(path));
+            auto g = loadOpenAsset(toStringz(path));
             auto immutableG = cast(immutable)g;
             main.send(immutableG, mytid);
           }else{ main.send("Unknown file", mytid); }
@@ -59,7 +59,7 @@ void initializeAsync(ref App app, uint numWorkers = 8){
   app.concurrency.paths ~= dir("data/objects/", "*.{obj,fbx}", false);
   app.concurrency.paths ~= dir("data/textures/", "*.{png,jpg}", false);
   foreach (i; 0 .. numWorkers) {
-    auto worker = new TaskThread(&app, thisTid);
+    auto worker = new TaskThread(thisTid, app.verbose > 0);
     worker.start();
     auto id = receiveOnly!Tid();
     app.concurrency.workers[id] = false;

--- a/src/engine/threading.d
+++ b/src/engine/threading.d
@@ -7,6 +7,7 @@ import engine;
 
 import assimp : loadOpenAsset, isOpenAsset, OpenAsset;
 import io : dir, fixPath;
+import bone : mergeBones;
 import images : deAllocate;
 import textures: isTexture, mapTextures, transferTextureAsync, toRGBA;
 
@@ -86,23 +87,7 @@ void checkAsync(ref App app) {
   receiveTimeout(dur!"msecs"(-1), (immutable(OpenAsset) message, Tid tid) {
     app.concurrency.workers[tid] = false;
     auto obj = cast(OpenAsset)cast(Geometry)message;
-    // Build local->global index map, then remap all vertices at once
-    uint[uint] indexMap;
-    foreach(boneName, ref bone; obj.bones) {
-      if(!(boneName in app.bones)) {
-        uint newIndex = cast(uint)app.bones.length;
-        indexMap[bone.index] = newIndex;
-        bone.index = newIndex;
-        app.bones[boneName] = bone;
-      } else {
-        indexMap[bone.index] = app.bones[boneName].index;
-      }
-    }
-    foreach(ref v; obj.vertices) {
-      foreach(i; 0..4) {
-        if(v.bones[i] in indexMap) v.bones[i] = indexMap[v.bones[i]];
-      }
-    }
+    app.mergeBones(obj);
     app.objects ~= obj;
     app.mapTextures(app.objects[($-1)]);
   });

--- a/src/engine/threading.d
+++ b/src/engine/threading.d
@@ -5,7 +5,7 @@
 
 import engine;
 
-import assimp : loadOpenAsset, isOpenAsset;
+import assimp : loadOpenAsset, isOpenAsset, OpenAsset;
 import io : dir, fixPath;
 import images : deAllocate;
 import textures: isTexture, mapTextures, transferTextureAsync, toRGBA;
@@ -85,7 +85,25 @@ void checkAsync(ref App app) {
   });
   receiveTimeout(dur!"msecs"(-1), (immutable(OpenAsset) message, Tid tid) {
     app.concurrency.workers[tid] = false;
-    app.objects ~= cast(Geometry)message;
+    auto obj = cast(OpenAsset)cast(Geometry)message;
+    // Build local->global index map, then remap all vertices at once
+    uint[uint] indexMap;
+    foreach(boneName, ref bone; obj.bones) {
+      if(!(boneName in app.bones)) {
+        uint newIndex = cast(uint)app.bones.length;
+        indexMap[bone.index] = newIndex;
+        bone.index = newIndex;
+        app.bones[boneName] = bone;
+      } else {
+        indexMap[bone.index] = app.bones[boneName].index;
+      }
+    }
+    foreach(ref v; obj.vertices) {
+      foreach(i; 0..4) {
+        if(v.bones[i] in indexMap) v.bones[i] = indexMap[v.bones[i]];
+      }
+    }
+    app.objects ~= obj;
     app.mapTextures(app.objects[($-1)]);
   });
   if(!app.textures.transfer) {

--- a/src/engine/threading.d
+++ b/src/engine/threading.d
@@ -86,7 +86,7 @@ void checkAsync(ref App app) {
   });
   receiveTimeout(dur!"msecs"(-1), (immutable(OpenAsset) message, Tid tid) {
     app.concurrency.workers[tid] = false;
-    auto obj = cast(OpenAsset)cast(Geometry)message;
+    auto obj = cast(OpenAsset)message;
     app.mergeBones(obj);
     app.objects ~= obj;
     app.mapTextures(app.objects[($-1)]);

--- a/src/objects/assimp.d
+++ b/src/objects/assimp.d
@@ -36,7 +36,7 @@ bool isOpenAsset(string path){
 
 /** Load an OpenAsset 
  */
-OpenAsset loadOpenAsset(ref App app, const(char)* path, bool isVisible = false) {
+OpenAsset loadOpenAsset(const(char)* path, bool verbose = false, bool isVisible = false) {
   SDL_Log("Loading: %s", path);
   OpenAsset object = new OpenAsset();
 
@@ -50,13 +50,13 @@ OpenAsset loadOpenAsset(ref App app, const(char)* path, bool isVisible = false) 
   }
 
   object.mName = stripExtension(baseName(to!string(path)));
-  object.mData = app.loadMetaData(scene);
+  object.mData = loadMetaData(scene, verbose);
 
   object.bounds.calculateBounds(scene, scene.mRootNode, Matrix());
 
-  object.materials = app.loadMaterials(scene, path);
-  object.animations = app.loadAnimations(scene, object);
-  object.rootnode = app.loadNode(object, scene, scene.mRootNode, Matrix());
+  object.materials = loadMaterials(scene, path);
+  object.animations = loadAnimations(scene, object, verbose);
+  object.rootnode = loadNode(object, scene, scene.mRootNode, Matrix(), verbose);
 
   if (object.mName == "Spider") { // The Spider model is broken, it floats above
     object.rootnode.transform = object.rootnode.transform.translate([0.0f, -775.0f, 0.0f]);
@@ -65,7 +65,7 @@ OpenAsset loadOpenAsset(ref App app, const(char)* path, bool isVisible = false) 
 
   object.instances[0] = object.bounds.computeScaleAdjustment(); // Adjust the scale to 4.0f
 
-  if (app.verbose) {
+  if (verbose) {
     SDL_Log("Model '%s' loaded successfully.", toStringz(object.mName));
     SDL_Log("%u meshes, %u materials, %u animations", scene.mNumMeshes, scene.mNumMaterials, scene.mNumAnimations);
     SDL_Log("%u vertices, %u indices loaded", object.vertices.length, object.indices.length);

--- a/src/objects/assimp.d
+++ b/src/objects/assimp.d
@@ -6,6 +6,7 @@
 import engine;
 
 import animation : loadAnimations;
+import bone : Bone;
 import boundingbox : computeBoundingBox, calculateBounds, computeScaleAdjustment;
 import matrix : toMatrix, multiply, inverse, transpose, rotate;
 import node : loadNode;
@@ -20,6 +21,7 @@ import vector : x, y, z, euclidean;
 /** OpenAsset using assimp
  */
 class OpenAsset : Geometry {
+  Bone[string] bones;   /// Local bone map, merged into app.bones on main thread
   this() {
     instances = [Instance()];
     name = (){ return(this.stringof); };

--- a/src/objects/turtle.d
+++ b/src/objects/turtle.d
@@ -33,6 +33,7 @@ class Turtle : Geometry {
       if(fmod(t.frame, 10) == 0) t.age(app, obj, dt);
       t.frame++;
     };
+    meshes["Turtle"] = Mesh([0, cast(uint)vertices.length]);
     name = (){ return(typeof(this).stringof); };
   }
 
@@ -96,6 +97,7 @@ class Turtle : Geometry {
         default: break;
       }
     }
+    meshes["Turtle"].vertices[1] = cast(uint)vertices.length;
     buffers[VERTEX] = false;
     buffers[INDEX] = false;
   }

--- a/src/scene.d
+++ b/src/scene.d
@@ -87,10 +87,12 @@ void createScene(ref App app){
     obj.rotate([0.0f, 2 * dt, 4 * dt]);
   };
 
+
   SDL_Log("createScene: Add L-System");
   app.objects ~= new Turtle(createLSystem());
   app.objects[($-1)].computeNormals();
-  app.objects[($-1)].position([4.5f, 2.5f, -2.0f]);
+  app.objects[($-1)].position([4.5f, 2.5f, -2.0f]); 
+
 
   SDL_Log("createScene: Add PDB object");
   auto protein = loadProteinCif("data/objects/3kql.cif");

--- a/src/scene.d
+++ b/src/scene.d
@@ -87,11 +87,10 @@ void createScene(ref App app){
     obj.rotate([0.0f, 2 * dt, 4 * dt]);
   };
 
-/*
   SDL_Log("createScene: Add L-System");
   app.objects ~= new Turtle(createLSystem());
   app.objects[($-1)].computeNormals();
-  app.objects[($-1)].position([4.5f, 2.5f, -2.0f]); */
+  app.objects[($-1)].position([4.5f, 2.5f, -2.0f]);
 
   SDL_Log("createScene: Add PDB object");
   auto protein = loadProteinCif("data/objects/3kql.cif");

--- a/src/scene.d
+++ b/src/scene.d
@@ -87,11 +87,10 @@ void createScene(ref App app){
     obj.rotate([0.0f, 2 * dt, 4 * dt]);
   };
 
-
-  SDL_Log("createScene: Add L-System");
+/*  SDL_Log("createScene: Add L-System");
   app.objects ~= new Turtle(createLSystem());
   app.objects[($-1)].computeNormals();
-  app.objects[($-1)].position([4.5f, 2.5f, -2.0f]); 
+  app.objects[($-1)].position([4.5f, 2.5f, -2.0f]); */
 
 
   SDL_Log("createScene: Add PDB object");

--- a/src/scene.d
+++ b/src/scene.d
@@ -87,10 +87,11 @@ void createScene(ref App app){
     obj.rotate([0.0f, 2 * dt, 4 * dt]);
   };
 
+/*
   SDL_Log("createScene: Add L-System");
   app.objects ~= new Turtle(createLSystem());
   app.objects[($-1)].computeNormals();
-  app.objects[($-1)].position([4.5f, 2.5f, -2.0f]);
+  app.objects[($-1)].position([4.5f, 2.5f, -2.0f]); */
 
   SDL_Log("createScene: Add PDB object");
   auto protein = loadProteinCif("data/objects/3kql.cif");

--- a/src/scene.d
+++ b/src/scene.d
@@ -87,11 +87,10 @@ void createScene(ref App app){
     obj.rotate([0.0f, 2 * dt, 4 * dt]);
   };
 
-/*  SDL_Log("createScene: Add L-System");
+  SDL_Log("createScene: Add L-System");
   app.objects ~= new Turtle(createLSystem());
   app.objects[($-1)].computeNormals();
-  app.objects[($-1)].position([4.5f, 2.5f, -2.0f]); */
-
+  app.objects[($-1)].position([4.5f, 2.5f, -2.0f]);
 
   SDL_Log("createScene: Add PDB object");
   auto protein = loadProteinCif("data/objects/3kql.cif");


### PR DESCRIPTION
Resolves multiple `VK_ERROR_DEVICE_LOST` (-4) crashes on Android (Pixel 9 Pro / Mali-G715) that did not manifest on Linux/Windows.

### Thread safety
- Worker threads no longer receive `App*`, eliminating data races on Vulkan handles
- `loadOpenAsset` no longer takes an `App` parameter; bone data is merged on the main thread via `mergeBones()`

### Mesh SSBO out-of-bounds (Turtle/L-system)
- Turtle had no entry in `meshes[]`, causing the fragment shader to read OOB from `meshSSBO`
- Fixed by registering `meshes["Turtle"]` in constructor and updating vertex count in `age()`

### Shadow pass barrier scope
- Removed `bufferGeometries(cmd)` from shadow pass; was causing cross-command-buffer barrier violations

### Async texture upload race condition (root cause of device lost)
- `transferTextureAsync` previously added textures to `app.textures` immediately on submit, before the GPU transfer completed; the renderer could then sample incomplete texture data
- Replaced single `cmdBuffer`/`transfer` flag with a `PendingTexture[]` list; each upload gets its own command buffer and fence
- Textures are only promoted to `app.textures` once their fence signals — no semaphores, no render stall, multiple concurrent uploads supported

### Barrier cleanup
- `updateBuffer`: replaced `VkBufferMemoryBarrier` (buffer-specific) with `VkMemoryBarrier` (global), consistent with Vulkan best practice for single-queue scenarios